### PR TITLE
Automated build scripts

### DIFF
--- a/scripts/bottle-all.ts
+++ b/scripts/bottle-all.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env -S tea -E
+
+/*---
+args:
+  - deno
+  - run
+  - --allow-net
+  - --allow-run
+  - --allow-read=/opt
+  - --allow-write=/opt
+  - --import-map={{ srcroot }}/import-map.json
+---*/
+
+import usePantry from "hooks/usePantry.ts"
+import { bottle } from "./bottle.ts";
+import { semver } from "types";
+import useCellar from "hooks/useCellar.ts";
+
+const pantry = usePantry();
+
+const projects = await pantry.ls()
+
+for await (const project of projects) {
+  const versions = await pantry.getVersions({ project, constraint: new semver.Range('*') })
+  const reqs = new Set(versions.map(v => `${v.major}.${v.minor}`))
+  for (const req of reqs) {
+    const version = { project: project, constraint: new semver.Range(req) }
+    if (!await useCellar().isInstalled(version)) { continue }
+    try {
+      await bottle(version)
+    } catch (error) {
+      console.verbose({ couldntBottle: { project, version }, error })
+    }
+  }
+}

--- a/scripts/bottle.ts
+++ b/scripts/bottle.ts
@@ -11,7 +11,7 @@ args:
   - --import-map={{ srcroot }}/import-map.json
 --- */
 
-import { parsePackageRequirement, Path } from "types"
+import { PackageRequirement, parsePackageRequirement, Path } from "types"
 import useCellar from "hooks/useCellar.ts"
 import useCache from "hooks/useCache.ts"
 import { run } from "utils"
@@ -19,12 +19,16 @@ import { run } from "utils"
 const cellar = useCellar()
 
 for (const req of Deno.args.map(parsePackageRequirement)) {
+  await bottle(req)
+}
+
+export async function bottle(req: PackageRequirement) {
   const { path: kegdir, pkg } = await cellar.resolve(req)
   const tarball = useCache().bottle(pkg)
 
   if (tarball.exists()) {
     console.verbose({ alreadyExists: tarball.string })
-    continue
+    return
   }
 
   const filesListName = "files.txt"

--- a/scripts/build-all.ts
+++ b/scripts/build-all.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env -S tea -E
+
+/*---
+args:
+  - deno
+  - run
+  - --allow-env
+  - --allow-net
+  - --allow-run
+  - --allow-read=/opt
+  - --allow-write=/opt
+  - --import-map={{ srcroot }}/import-map.json
+---*/
+
+import usePantry from "hooks/usePantry.ts"
+import hydrate from "prefab/hydrate.ts"
+import build from "prefab/build.ts"
+import doInstall from "prefab/install.ts"
+import { lvl1 as link } from "prefab/link.ts"
+import { semver, PackageRequirement, Package } from "types"
+import useCache from "hooks/useCache.ts"
+import useCellar from "hooks/useCellar.ts"
+import useSourceUnarchiver from "hooks/useSourceUnarchiver.ts"
+import { S3 } from "https://deno.land/x/s3@0.5.0/mod.ts";
+
+const pantry = usePantry();
+const projects = await pantry.ls()
+
+const s3 = new S3({
+  accessKeyID: Deno.env.get("AWS_ACCESS_KEY_ID")!,
+  secretKey: Deno.env.get("AWS_SECRET_ACCESS_KEY")!,
+  region: "us-east-1",
+});
+
+const bucket = s3.getBucket(Deno.env.get("S3_BUCKET")!);
+
+for await (const project of projects) {
+  try {
+    const req = { project, constraint: new semver.Range('*') }
+    await buildIfNeeded({ project: req, install: false })
+  } catch (error) {
+    console.error({ couldntBuild: project, error })
+  }
+}
+
+interface BuildOptions {
+  project: PackageRequirement
+  install: boolean
+}
+
+async function buildIfNeeded({ project, install }: BuildOptions) {
+  console.verbose({ building: project, install })
+  const versions = await pantry.getVersions(project)
+
+  if (project.constraint.raw == "*") {
+    const reqs = new Set(versions.map(v => `${v.major}.${v.minor}`))
+    for (const req of reqs) {
+      const build = { project: project.project, constraint: new semver.Range(req) }
+      try {
+        await buildIfNeeded({ project: build, install })
+      } catch (error) {
+        console.verbose({ couldntBuild: { project, req }, error })
+      }
+    }
+    return
+  }
+  const version = semver.maxSatisfying(versions, project.constraint)
+  if (!version) throw "no-version-found"
+  const pkg = { project: project.project, version }
+
+  // No need to rebuild anything we've got.
+  if (await useCellar().isInstalled(pkg)) {
+    console.verbose({ alreadyInstalled: pkg })
+    return;
+  }
+  try {
+    if (install) {
+      await doInstall(pkg)
+    } else if (await bucket.headObject(useCache().s3Key(pkg))) {
+      console.verbose({ alreadyUploaded: pkg })
+    } else {
+      throw "cannot-satisfy-dep"
+    }
+    return
+  } catch {
+    console.verbose({ building: project })
+  }
+
+  const deps = await pantry.getDeps({ pkg, wbuild: true })
+  const graph = await hydrate(deps)
+
+  for (const dep of graph) {
+    await buildIfNeeded({ project: dep, install: true })
+  }
+
+  await prepare(pkg)
+  try {
+    const path = await build({ pkg, deps: graph })
+    await link({ path, pkg })
+  } catch (error) {
+    console.verbose({ failedToBuild: pkg, error })
+  } finally {
+    useCellar().mkpath(pkg).join("src").rm({ recursive: true })
+  }
+}
+
+async function prepare(pkg: Package) {
+  const dstdir = useCellar().mkpath(pkg).join("src")
+  const { url, stripComponents } = await pantry.getDistributable(pkg)
+  const { download } = useCache()
+  const zip = await download({ pkg, url, type: 'src' })
+  await useSourceUnarchiver().unarchive({
+    dstdir,
+    zipfile: zip,
+    stripComponents
+  })
+}

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -52,7 +52,7 @@ for (const req of args[0].map(parsePackageRequirement)) {
   await link({ path, pkg })
 }
 
-async function prepare(pkg: Package) {
+export async function prepare(pkg: Package) {
   const dstdir = useCellar().mkpath(pkg).join("src")
   const { url, stripComponents } = await pantry.getDistributable(pkg)
   const { download } = useCache()

--- a/scripts/upload-sync.ts
+++ b/scripts/upload-sync.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env -S tea -E
+
+/*---
+args:
+  - deno
+  - run
+  - --allow-net
+  - --allow-env
+  - --allow-read=/opt/tea.xyz/var/www
+  - --import-map={{ srcroot }}/import-map.json
+---*/
+
+import { S3 } from "https://deno.land/x/s3@0.5.0/mod.ts";
+import useCache from "hooks/useCache.ts";
+
+const s3 = new S3({
+  accessKeyID: Deno.env.get("AWS_ACCESS_KEY_ID")!,
+  secretKey: Deno.env.get("AWS_SECRET_ACCESS_KEY")!,
+  region: "us-east-1",
+});
+
+const bucket = s3.getBucket(Deno.env.get("S3_BUCKET")!);
+
+for (const pkg of await useCache().ls()) {
+  const key = useCache().s3Key(pkg)
+  const bottle = useCache().bottle(pkg)
+
+  console.log({ checking: key });
+
+  if (!await bucket.headObject(key)) {
+    // path.read() returns a string; this is easier to get a UInt8Array
+    const contents = await Deno.readFile(bottle.string);
+
+    await bucket.putObject(key, contents);
+
+    console.log({ uploaded: key });
+  }
+}

--- a/src/hooks/useCache.ts
+++ b/src/hooks/useCache.ts
@@ -12,6 +12,7 @@ interface DownloadOptions {
 
 interface Response {
   bottle(pkg: Package): Path
+  s3Key(pkg: Package): string
   download(opts: DownloadOptions): Promise<Path>
   ls(): Promise<Package[]>
 }
@@ -67,7 +68,12 @@ export default function useCache(): Response {
     return rv.sort(packageSort)
   }
 
-  return { download, bottle, ls }
+  const s3Key = (pkg: Package) => {
+    const { platform, arch } = usePlatform()
+    return `${pkg.project}/${platform}/${arch}/v${pkg.version.version}.tar.gz`
+  }
+
+  return { download, bottle, ls, s3Key }
 }
 
 async function grab({ readURL, writeFilename }: { readURL: string, writeFilename: Path }) {


### PR DESCRIPTION
Trimmed way down. This now only:

- `scripts/bottle-all.ts`: bottles every package installed on the system which is not already bottled
- `scripts/bottle.ts`: export bottling function for reuse
- `scripts/build-all.ts`: builds the latest of each minor which is not already built/bottled/or in our repository. takes... a while to run
- `scripts/build.ts`: export prepare function for reuse
- `scripts/upload-sync.ts`: uploads any present bottles to the repo that don't already exist
- `hooks/useCache.ts`: provide a canonical generator for the S3 object key for a given `Package`

requires ~~#13~~ #14 #15 #16 #17 #18 #19 #21

~Provides:~

- ~`scripts/build-all.ts`: builds the most recent release of each minor version of each package in the pantry, and any missing dependencies, if not already present in the repository.~
- ~`scripts/bottle-all.ts`: bottles every package currently built on the system.~
- ~`scripts/upload-sync.ts`: compares local bottle list against `tea` repository, and uploads any not yet present.~

~Changes:~

- ~`scripts/bottle.ts`: export main logic for reuse. Compress bottles using gzip to match extension.~
- ~`hooks/useCache.ts`: alter `download()` to take a `type: 'src' | 'bottle'` so we don't use the same filename for both.~
- ~`hooks/useGitHubAPI.ts`: accept a string regex of release keys to ignore from `package.yml`.~
- ~`hooks/usePantry.ts`: allow `{{arch}}` and `{{target}}` substitutions in `package.yml`. Provide `ls()` to walk the pantry and list all projects.~
- ~`hooks/usePlatform.ts`: add `shell: 'sh' | 'bash'` to `Return` to account for shell differences between darwin and linux.~
- ~`types/Path.ts`: add `clean()` to remove `/src` from paths.~
- ~`utils.ts`: modify `GET<T>()` to limit temporal caching to 3600s. Fixes infinite caching of GitHubAPI.~