### PR TITLE
Add ls() helpers to useCache/usePantry

### DIFF
--- a/src/hooks/useCellar.ts
+++ b/src/hooks/useCellar.ts
@@ -1,4 +1,5 @@
 import { Path, Package, PackageRequirement, SemVer, semver, Installation } from "types"
+import { packageSort } from "utils"
 
 //TODO useCellar should take a project name and then all functions operate on that
 
@@ -35,7 +36,7 @@ export default function useCellar(): Return {
         //TODO only semver errors
       }
     }
-    return rv
+    return rv.sort((a, b) => packageSort(a.pkg, b.pkg))
   }
 
   const resolve = async (pkg: Package | PackageRequirement) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -119,6 +119,11 @@ export async function attempt<T>(body: () => Promise<T>, opts: {swallow: unknown
   }
 }
 
+export function packageSort(a: Package, b: Package): number {
+  return a.project === b.project
+    ? a.version.compare(b.version)
+    : (a.project < b.project ? -1 : 1)
+}
 
 /////////////////////////////////////////////////////////////////// Unarchiver
 import { Unarchiver, TarballUnarchiver, ZipUnarchiver } from "./utils/Unarchiver.ts"
@@ -126,7 +131,7 @@ export { Unarchiver, TarballUnarchiver, ZipUnarchiver }
 
 
 ////////////////////////////////////////////////////////////////////////// run
-import { Path } from "types"
+import { Package, Path } from "types"
 
 interface RunOptions extends Omit<Deno.RunOptions, 'cmd'|'cwd'> {
   cmd: (string | Path)[] | Path


### PR DESCRIPTION
- `useCache().ls()`: finds all tarballs in `/opt/tea.xyz/var/www` for the arch we're running and return a `Package[]`
- `useCellar().ls()`: sort by package name > package version
- `usePantry().ls()`: returns a `string[]` of valid packages in the pantry