### PR TITLE
Append +${arch} or +src to tarballs as appropriate

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -56,7 +56,7 @@ async function prepare(pkg: Package) {
   const dstdir = useCellar().mkpath(pkg).join("src")
   const { url, stripComponents } = await pantry.getDistributable(pkg)
   const { download } = useCache()
-  const zip = await download({ pkg, url })
+  const zip = await download({ pkg, url, type: 'src' })
   await useSourceUnarchiver().unarchive({
     dstdir,
     zipfile: zip,


### PR DESCRIPTION
- `scripts/bottle.ts`: don't overwrite existing bottles (TODO: --force option), do compress the tarballs.
- `scripts/build.ts`: support type hints for downloading `src` to a different path.
- `hooks/useCache.ts`: differentiate src from bottle destinations. take an optional flag to download to differentiate.