### PR TITLE
have isInstalled() check looksEmpty()

### DIFF
--- a/src/hooks/useCellar.ts
+++ b/src/hooks/useCellar.ts
@@ -62,7 +62,11 @@ export default function useCellar(): Return {
 
   const mkpath = (pkg: Package) => prefix.join(pkg.project, `v${pkg.version}`).mkpath()
 
-  const isInstalled = (pkg: Package | PackageRequirement) => resolve(pkg).swallow(/^not-found:/)
+  const isInstalled = async (pkg: Package | PackageRequirement) => {
+    const resolution = await resolve(pkg).swallow(/^not-found:/)
+    if (resolution && await looksEmpty(resolution.path)) { return undefined }
+    return resolution
+  }
 
   return { resolve, ls, mkpath, prefix, shelf, isInstalled }
 }


### PR DESCRIPTION
- `hooks/useCellar.ts`: `isInstalled()` was counting an extant directory as an install. applied our helpful `looksEmpty()` helper to better check.