### PR TITLE
a few small bugs

### DIFF
--- a/scripts/bottle.ts
+++ b/scripts/bottle.ts
@@ -24,12 +24,12 @@ for (const req of Deno.args.map(parsePackageRequirement)) {
 
   const files = await walk(kegdir, path => {
     switch (path.relative({ to: kegdir })) {
-      case 'src':
-      case 'build.sh':
-      case filesListName:
-        return 'skip'
-      default:
-        return 'accumulate'
+    case 'src':
+    case 'build.sh':
+    case filesListName:
+      return 'skip'
+    default:
+      return 'accumulate'
     }
   })
   const relativePaths = files.map(x => x.relative({ to: cellar.prefix }))

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -7,7 +7,7 @@ args:
   - --allow-net
   - --allow-write=/opt
   - --allow-read
-  - --allow-env=HOME,VERBOSE,DEBUG,MUGGLE,PATH,MANPATH,PKG_CONFIG_PATH
+  - --allow-env=HOME,VERBOSE,DEBUG,MUGGLE,PATH,MANPATH,PKG_CONFIG_PATH,GITHUB_TOKEN,MAGIC
   - --allow-run
   - --import-map={{ srcroot }}/import-map.json
 ---*/

--- a/scripts/self-install.ts
+++ b/scripts/self-install.ts
@@ -14,12 +14,13 @@ import { Path } from "types"
 import { undent } from "utils"
 
 //TODO version of deno should be determined from the requirements file
+//TODO /usr/local/bin not world writable by default on linux
 
 const srcroot = Deno.env.get("SRCROOT")!
 const exefile = Path.root.join("usr/local/bin/tea")
 const text = undent`
   #!/bin/sh
-  exec /opt/deno.land/v1.20/bin/deno \\
+  exec /opt/deno.land/v'*'/bin/deno \\
     run \\
     --allow-read --allow-write=/opt --allow-net --allow-run --allow-env \\
     --import-map='${srcroot}'/import-map.json \\
@@ -27,4 +28,4 @@ const text = undent`
     "$@"
   `
 
-exefile.write({ force: true, text }).chmod(0o500)
+exefile.write({ force: true, text }).chmod(0o555)

--- a/src/hooks/useCache.ts
+++ b/src/hooks/useCache.ts
@@ -1,6 +1,7 @@
 import { copy, readerFromStreamReader } from "deno/streams/mod.ts"
 import { Package, Path } from "types"
 import usePlatform from "hooks/usePlatform.ts"
+import * as _ from "utils" // console.verbose
 
 interface DownloadOptions {
   url: string

--- a/src/prefab/build.ts
+++ b/src/prefab/build.ts
@@ -3,7 +3,7 @@ import usePantry from "hooks/usePantry.ts"
 import useCellar from "hooks/useCellar.ts"
 import useShellEnv from "hooks/useShellEnv.ts"
 import { run, undent } from "utils"
-import usePlatform from "../hooks/usePlatform.ts";
+import usePlatform from "hooks/usePlatform.ts";
 
 interface Options {
   pkg: Package


### PR DESCRIPTION
- `scripts/bottle.ts`: consistent `case` indents
- `scripts/build.ts`: include new ENV keys in allow statement
- `scripts/self-install.ts`: don't hardcode `deno` version. set more permissive (0555) perms for `/usr/local/bin/tea`
- `hooks/useCache.ts`: load `utils` for `console.verbose()` for scripts that wouldn't otherwise
- `prefab/build.ts`: use import-mapped imports