### PR TITLE
Don't cache responses from the GitHub API

### DIFF
--- a/src/hooks/useGitHubAPI.ts
+++ b/src/hooks/useGitHubAPI.ts
@@ -1,3 +1,4 @@
+import { RELOAD_POLICY } from "https://raw.githubusercontent.com/mxcl/deno-cache/main/mod.ts";
 import { semver, SemVer } from "types"
 import { flatMap, GET } from "utils"
 
@@ -19,7 +20,7 @@ interface GHRelease {
 
 export default function useGitHubAPI(): Response {
   const getVersions = async ({ user, repo }: GetVersionsOptions) => {
-    const releases = await GET<GHRelease[]>(`https://api.github.com/repos/${user}/${repo}/releases`)
+    const releases = await GET<GHRelease[]>(`https://api.github.com/repos/${user}/${repo}/releases`, RELOAD_POLICY)
     return releases.compactMap(({ tag_name, name }) => {
       //TODO should be explicit if you want coerce
       return flatMap(tag_name ?? name, x => semver.coerce(x))

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,8 +16,8 @@ export function download(
   return cache(url, policy, ns)
 }
 
-export async function GET<T>(url: string): Promise<T> {
-  const foo = await download(url)
+export async function GET<T>(url: string, policy: Policy | undefined = undefined): Promise<T> {
+  const foo = await download(url, policy)
   const txt = await Deno.readTextFile(foo.path)
   const json = JSON.parse(txt)
   return json as T


### PR DESCRIPTION
Without a policy, API responses will be cached forever, and no new version of any package will every be visible.