### PR TITLE
Provide clean-all.sh to remove all `tea` product directories

### DIFF
--- a/scripts/clean-all.sh
+++ b/scripts/clean-all.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env -S tea -E
+
+_="
+---
+args: /bin/sh
+---
+"
+
+ROOTS=$(ls /opt/tea.xyz/var/pantry/projects)
+
+for x in $ROOTS
+do
+  if [ "X$x" = "X" ]
+  then
+    continue
+  fi
+  rm -rf /opt/"$x"
+done
+
+rm /opt/tea.xyz/var/www/*.tar.gz


### PR DESCRIPTION
Useful for switching build arches, or just starting fresh