### PR TITLE
Use the sanitized package name consistently

### DIFF
--- a/src/hooks/useCache.ts
+++ b/src/hooks/useCache.ts
@@ -56,7 +56,9 @@ export default function useCache(): Response {
     for await (const file of prefix.ls()) {
       const match = file[1].name.match(`^(.*)-([0-9]+\\.[0-9]+\\.[0-9]+)\\+${arch}\\.tar\\.gz$`)
       if (!match) { continue }
-      const [_, project, v] = match
+      const [_, p, v] = match
+      // Gotta undo the package name manipulation to get the package from the bottle
+      const project = p.replaceAll("∕", "/")
       const version = semver.coerce(v)
       if (!version) { continue }
       rv.push({ project, version })

--- a/src/prefab/install.ts
+++ b/src/prefab/install.ts
@@ -20,12 +20,13 @@ import { encodeToString } from "https://deno.land/std@0.97.0/encoding/hex.ts";
 
 export default async function install(pkg: Package): Promise<Installation> {
   const { project, version } = pkg
-  const { platform, arch, finalizeInstall } = usePlatform()
-  const url = `https://s3.amazonaws.com/dist.tea.xyz/${project}/${platform}/${arch}/v${version}.tar.gz`
+  const { finalizeInstall } = usePlatform()
+  const { s3Key, download } = useCache()
+  const url = `https://s3.amazonaws.com/dist.tea.xyz/${s3Key(pkg)}`
   const { prefix: dstdir, ...cellar } = useCellar()
   const { verbosity } = useFlags()
 
-  const tarball = await useCache().download({ url, pkg: { project, version } })
+  const tarball = await download({ url, pkg: { project, version } })
 
   try {
     await validateChecksum(tarball, `${url}.sha256sum`)


### PR DESCRIPTION
- `hooks/useCache.ts`: properly sanitize the package name in both the `stem` and `s3Key` functions.
- `prefab/build.ts`: `finalizeInstall()` could fail on overly-restrictive permissions on `build.sh`.
- `prefab/install.ts`: use proper `s3Key()` for download URL.