### PR TITLE
Move usePantry().ls() out into bottle-all.ts.

### DIFF
--- a/scripts/build-all.ts
+++ b/scripts/build-all.ts
@@ -8,7 +8,7 @@ args:
   - --allow-run
   - --allow-read=/opt
   - --allow-write=/opt
-  - --allow-env=AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,S3_BUCKET,GITHUB_TOKEN,VERBOSE,DEBUG,MAGIC,PATH,MANPATH,PKG_CONFIG_PATH,LIBRARY_PATH,CPATH,XDG_DATA_DIRS
+  - --allow-env=AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,S3_BUCKET,GITHUB_TOKEN,VERBOSE,DEBUG,MAGIC,PATH,MANPATH,PKG_CONFIG_PATH,LIBRARY_PATH,CPATH,XDG_DATA_DIRS,CMAKE_PREFIX_PATH
   - --import-map={{ srcroot }}/import-map.json
 ---*/
 
@@ -22,9 +22,9 @@ import useCache from "hooks/useCache.ts"
 import useCellar from "hooks/useCellar.ts"
 import useSourceUnarchiver from "hooks/useSourceUnarchiver.ts"
 import { S3 } from "s3";
+import { lsPantry } from "./bottle-all.ts";
 
 const pantry = usePantry();
-const projects = await pantry.ls()
 
 const s3 = new S3({
   accessKeyID: Deno.env.get("AWS_ACCESS_KEY_ID")!,
@@ -39,7 +39,7 @@ const results: { built: string[], failed: string[] } = {
   failed: []
 }
 
-for await (const project of projects) {
+for await (const project of lsPantry()) {
   try {
     const req = { project, constraint: new semver.Range('*') }
     await buildIfNeeded({ project: req, install: false })

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -8,7 +8,7 @@ args:
   - --allow-run
   - --allow-read=/opt
   - --allow-write=/opt
-  - --allow-env=VERBOSE,DEBUG,MAGIC,PATH,MANPATH,PKG_CONFIG_PATH,GITHUB_TOKEN,CPATH,LIBRARY_PATH,XDG_DATA_DIRS
+  - --allow-env=VERBOSE,DEBUG,MAGIC,PATH,MANPATH,PKG_CONFIG_PATH,GITHUB_TOKEN,CPATH,LIBRARY_PATH,XDG_DATA_DIRS,CMAKE_PREFIX_PATH
   - --import-map={{ srcroot }}/import-map.json
 ---*/
 

--- a/src/hooks/usePantry.ts
+++ b/src/hooks/usePantry.ts
@@ -3,7 +3,6 @@ import useGitHubAPI from "hooks/useGitHubAPI.ts"
 import { run, flatMap, isNumber, isPlainObject, isString, isArray, undent } from "utils"
 import useCellar from "hooks/useCellar.ts"
 import usePlatform from "hooks/usePlatform.ts"
-import { join } from "deno/path/mod.ts";
 
 
 interface GetDepsOptions {
@@ -19,8 +18,6 @@ interface Response {
   getBuildScript(pkg: Package): Promise<string>
   update(): Promise<void>
   getProvides(rq: PackageRequirement | Package): Promise<string[]>
-  /// list all packages in the pantry
-  ls(): Promise<string[]>
 }
 
 interface Entry {
@@ -172,21 +169,7 @@ export default function usePantry(): Response {
     })
   }
 
-  const ls = async (path = "") => {
-    let rv: string[] = []
-    for await (const p of Deno.readDir(`${prefix}/${path}`)) {
-      const name = join(path, p.name)
-      try {
-        await entry({ project: name, constraint: new semver.Range('*') }).yml();
-        rv.push(name)
-      } catch {
-        rv = rv.concat(await ls(name))
-      }
-    }
-    return rv.sort();
-  }
-
-  return { getVersions, getDeps, getDistributable, getBuildScript, update, getProvides, ls }
+  return { getVersions, getDeps, getDistributable, getBuildScript, update, getProvides }
 }
 
 


### PR DESCRIPTION
Instead of using `entry()` to avoid `readDir()` calls, walk the tree sanely like someone who doesn't want to introduce bugs