### PR TITLE
fix ssl certfile env var

### DIFF
--- a/src/hooks/useShellEnv.ts
+++ b/src/hooks/useShellEnv.ts
@@ -65,6 +65,9 @@ export default function useShellEnv({installations, pending, pristine}: Options)
     if (installation.pkg.project === 'openssl.org') {
       vars.SSL_CERT_FILE ??= []
       vars.SSL_CERT_FILE.compact_unshift(installation.path.join("ssl/cert.pem").compact()?.string)
+      // this is a single file, so we assume the first
+      // valid entry is correct
+      vars.SSL_CERT_FILE = vars.SSL_CERT_FILE.slice(0, 1)
     }
   }
 


### PR DESCRIPTION
SSL_CERT_FILE is a single file, not a group of paths. It's getting two copies of the same path, which is breaking the [test for openssl.org](https://github.com/teaxyz/pantry/actions/runs/3286359044). This change is a sufficient fix.