### PR TITLE
use OrderedSet for useShellEnv to prevent duplicates

### DIFF
--- a/import-map.json
+++ b/import-map.json
@@ -13,6 +13,7 @@
     "is_what": "https://deno.land/x/is_what@v4.1.7/src/index.ts",
     "cliffy/": "https://deno.land/x/cliffy@v0.25.0/",
     "s3": "https://deno.land/x/s3@0.5.0/mod.ts",
-    "outdent": "https://deno.land/x/outdent@v0.8.0/mod.ts"
+    "outdent": "https://deno.land/x/outdent@v0.8.0/mod.ts",
+    "rimbu/": "https://deno.land/x/rimbu@0.12.3/"
   }
 }


### PR DESCRIPTION
This uses the OrderedSet to prevent duplication in the shell env.

Resolves mxcl concerns [here](https://github.com/teaxyz/cli/pull/87#issuecomment-1285442532)