### PR TITLE
if neither CLT or Xcode installed then don’t x git

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ that part; it’s going to *change the world*.
 &nbsp;
 
 
-# tea/cli 0.10.0
+# tea/cli 0.10.1
 
 tea is a universal virtual‑environment manager:
 


### PR DESCRIPTION
Because `git` fails in those cases, and thus our installer fails and `tea --sync` fails.

Instead use the fallback method where we download the tarballs.