### PR TITLE
fix: Outputting color codes on non-tty

### DIFF
--- a/src/hooks/useLogger.ts
+++ b/src/hooks/useLogger.ts
@@ -31,11 +31,18 @@ export default function useLogger(prefix?: string) {
   return new Logger(prefix)
 }
 
-export const teal = (x: string) => colors.rgb8(x, 86)
-export const red = colors.brightRed
-export const gray = (x: string) => colors.rgb8(x, 244)
-export const dark = (x: string) => colors.rgb8(x, 238)
-export const lite = (x: string) => colors.rgb8(x, 252)
+function colorIfTTY(x: string, colorMethod: (x: string)=>string) {
+  if(Deno.isatty(Deno.stdout.rid) && Deno.isatty(Deno.stderr.rid)) {
+    return colorMethod(x)
+  }
+  return x
+}
+
+export const teal = (x: string) => colorIfTTY(x, (x) => colors.rgb8(x, 86))
+export const red = (x: string) => colorIfTTY(x, colors.brightRed)
+export const gray = (x: string) => colorIfTTY(x, (x) => colors.rgb8(x, 244))
+export const dark = (x: string) => colorIfTTY(x, (x) => colors.rgb8(x, 238))
+export const lite = (x: string) => colorIfTTY(x, (x) => colors.rgb8(x, 252))
 
 export class Logger {
   readonly prefix: string


### PR DESCRIPTION
I don't know if this is the best way to do it, but it certainly is *a way* to do it. I think it is somewhat elegant that it does not need to modify the behavior of any other files.

ref: #3