### PR TITLE
don't constrain cyclic deps to build version

### DIFF
--- a/src/prefab/hydrate.ts
+++ b/src/prefab/hydrate.ts
@@ -61,6 +61,10 @@ export default async function hydrate(
 
       for (const dep of await get_deps(node.pkg, initial_set.has(node.project))) {
         if (children.has(dep.project)) {
+          const self = graph[dep.project]
+          if (self.pkg.constraint === target.pkg.constraint) {
+            self.pkg.constraint = dep.constraint
+          }
           if (!bootstrap.has(dep.project)) {
             console.warn(`${dep.project} must be bootstrapped to build ${node.project}`)
 


### PR DESCRIPTION
requires #406 to pass checks

fixes https://github.com/teaxyz/cli/issues/412

Basically if a dep requests the target (`go.dev` requires `go.dev: '*'`), this will prevent locked loop (build `go.dev=1.20.1` trying to install `go.dev=1.20.1`)