### PR TITLE
Fix small typo in `dev` docs

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -4,7 +4,7 @@
 `dev` requires shell integration.
 
 ```sh
-pkgx integrate --dry-run`
+pkgx integrate --dry-run
 ```
 
 {% endhint %}


### PR DESCRIPTION
The first codeblock in the `dev` docs had an extra backtick at the end. This PR just removes it 