### PR TITLE
fix one-liner command

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -132,7 +132,7 @@ $ pkgx your-package --args
 You can also recommend our shell one-liner if you like:
 
 ```sh
-sh <(curl pkgx.sh) +your-package sh
+sh <(curl https://pkgx.sh) +your-package sh
 ```
 
 Will for example install pkgx and your pkg then open a new shell with it


### PR DESCRIPTION
... since the URL returns a 301 with "Moved Permanently" HTML without the https.

Of course, I'm sure we'd prefer if the DNS got fixed and we don't need to type the full "https://" and we can throw this away.