### PR TITLE
`pkgx +foo -- bar` should search `bar` in `PATH`

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -182,6 +182,12 @@ this flag can help in confusing situations.
 
 For now `rm -rf ~/.pkgx` is enough.
 
+*Coming Soon*.
+
+```sh
+pkgx uninstall pkgx
+```
+
 {% hint style="warning" %}
 
 ### Caveats

--- a/docs/run/anywhere/docker.md
+++ b/docs/run/anywhere/docker.md
@@ -59,7 +59,7 @@ RUN eval "$(curl https://pkgx.sh)" && dev && npm start
 Alternatively you can use `pkgx integrate` provided docker is instructed to
 use a more advanced shell like bash:
 
-```
+```Dockerfile
 FROM ubuntu
 SHELL ["/bin/bash", "-c"]
 RUN curl https://pkgx.sh | sh

--- a/docs/running-anything.md
+++ b/docs/running-anything.md
@@ -145,10 +145,17 @@ scripts, etc. since you want these to work forever.
 ## Running System Commands
 
 It can be useful to run system commands with a package environment injected.
-To do this specify the full path of the system executable:
+To do this either specify the full path of the system executable:
 
 ```sh
 pkgx +llvm.org /usr/bin/make
+```
+
+Or use `--` which is the standard POSIX way to tell tools like `pkgx` to stop
+processing args:
+
+```sh
+pkgx +llvm.org -- make  # finds `make` in PATH, failing if none found
 ```
 
 {% hint style="warning" %}

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,7 +42,7 @@ export default async function({ flags, ...opts }: Args, logger_prefix?: string) 
     if (args[0] == 'sh') {
       await repl(args.slice(1), { update, pkgs, logger })
     } else {
-      await x(args, { update, pkgs, logger })
+      await x({ args, unknown: opts.unknown, update, pkgs, logger })
     }
   } break
   case 'integrate':

--- a/src/modes/x.test.ts
+++ b/src/modes/x.test.ts
@@ -12,14 +12,14 @@ import * as mock from "deno/testing/mock.ts"
 
 Deno.test("x.ts", async runner => {
 
-  const opts = { update: false, logger: { replace: () => {}, clear: () => {}, upgrade: () => null as any } }
+  const opts = { unknown: [], update: false, logger: { replace: () => {}, clear: () => {}, upgrade: () => null as any } }
 
   await runner.step("unprovided throws", async () => {
     const stub1 = mock.stub(_internals, "which", () => Promise.resolve(undefined))
     const stub2 = mock.stub(_internals, "useSync", () => Promise.resolve(undefined))
     try {
       await assertRejects(
-        () => specimen(faker_args(), opts),
+        () => specimen({args: faker_args(), ...opts}),
         ProvidesError)
     } finally {
       stub1.restore()
@@ -37,7 +37,7 @@ Deno.test("x.ts", async runner => {
     })
 
     try {
-      await specimen(args, opts)  //TODO shouldn't be specifying update: false, should just be mocking libpkgx
+      await specimen({args, ...opts})  //TODO shouldn't be specifying update: false, should just be mocking libpkgx
 
       assertEquals(stub1.calls.length, 1)
       assertEquals(stub1.calls[0].args[0].cmd, args)
@@ -63,7 +63,7 @@ Deno.test("x.ts", async runner => {
     const stub4 = mock.stub(_internals, "which", () => Promise.resolve({...pkg, shebang: args.slice(0, 1) }))
 
     try {
-      await runner.step("std", () => specimen(args, opts))
+      await runner.step("std", () => specimen({args, ...opts}))
 
       assertEquals(stub1.calls.length, 1)
       assertEquals(stub1.calls[0].args[0].cmd, args)
@@ -72,7 +72,7 @@ Deno.test("x.ts", async runner => {
         const stub5 = mock.stub(_internals, "getenv", () => undefined)
         const new_args = [`${args[0]}@latest`, ...args.slice(1)]
         try {
-          await runner.step("std", () => specimen(new_args, opts))
+          await runner.step("std", () => specimen({args: new_args, ...opts}))
         } finally {
           stub5.restore()
         }
@@ -80,7 +80,7 @@ Deno.test("x.ts", async runner => {
         assertEquals(stub1.calls.length, 2)
         assertEquals(stub1.calls[1].args[0].cmd, args)
 
-        await runner.step("std w/update-set", () => specimen(new_args, {...opts, update: new Set()}))
+        await runner.step("std w/update-set", () => specimen({args: new_args, ...opts, update: new Set()}))
 
         assertEquals(stub1.calls.length, 3)
         assertEquals(stub1.calls[2].args[0].cmd, args)
@@ -88,7 +88,7 @@ Deno.test("x.ts", async runner => {
       await runner.step("invalid PKGX_LVL", async () => {
         const stub = mock.stub(_internals, "getenv", () => "")
         try {
-          await assertRejects(() => specimen(args, opts))
+          await assertRejects(() => specimen({args, ...opts}))
         } finally {
           stub.restore()
         }
@@ -111,7 +111,7 @@ Deno.test("x.ts", async runner => {
     const args = ['foo', 'bar']
     const stub4 = stub_execve()
     try {
-      await specimen(['foo@3', 'bar'], opts)
+      await specimen({args: ['foo@3', 'bar'], ...opts})
 
       assertEquals(stub4.calls.length, 1)
       assertEquals(stub4.calls[0].args[0].cmd, args)
@@ -134,7 +134,7 @@ Deno.test("x.ts", async runner => {
     const stub3 = stub_execve()
     const stub4 = mock.stub(_internals, "construct_env", () => (Promise.resolve({})))
     try {
-      await specimen(['foo', 'baz'], opts)
+      await specimen({args: ['foo', 'baz'], ...opts})
 
       assertEquals(stub3.calls.length, 1)
       assertEquals(stub3.calls[0].args[0].cmd, args)
@@ -179,7 +179,7 @@ Deno.test("x.ts", async runner => {
     const stub5 = mock.stub(_internals, "install", () => Promise.resolve({ installations, pkgenv: []}))
     const stub6 = mock.stub(_internals, "construct_env", () => (Promise.resolve({})))
     try {
-      await specimen(["foo@3", "bar"], opts)
+      await specimen({args: ["foo@3", "bar"], ...opts})
 
       assertEquals(stub4.calls.length, 1)
       assertEquals(stub4.calls[0].args[0].cmd, ["foo", "bar"])
@@ -197,7 +197,7 @@ Deno.test("x.ts", async runner => {
     const stub2 = mock.stub(_internals, "useSync", async () => { fail() })
     try {
       await assertRejects(
-        () => specimen(["/foo/bar"], opts),
+        () => specimen({args: ["/foo/bar"], ...opts}),
         PkgxError)
     } finally {
       stub1.restore()
@@ -215,7 +215,7 @@ Deno.test("x.ts", async runner => {
 
     try {
       Deno.chdir(newwd.string)
-      await specimen(["foo"], opts)
+      await specimen({args: ["foo"], ...opts})
 
       assertEquals(stub3.calls.length, 1)
       assertEquals(stub3.calls[0].args[0].cmd, ["foo"])
@@ -237,7 +237,7 @@ Deno.test("x.ts", async runner => {
     const stub5 = mock.stub(_internals, "construct_env", () => (Promise.resolve({})))
 
     try {
-      await specimen(["foo", "bar"], opts)
+      await specimen({args: ["foo", "bar"], ...opts})
 
       assertEquals(i, 2)
       assertEquals(useSyncCalled, 1)
@@ -272,7 +272,7 @@ Deno.test("x.ts", async runner => {
     const stub6 = mock.stub(_internals, "get_shebang", () => Promise.resolve(shebang_args))
 
     try {
-      await specimen([f.string, ...args_to_script], opts)
+      await specimen({args: [f.string, ...args_to_script], ...opts})
 
       assertEquals(stub1.calls.length, 1)
       assertEquals(stub1.calls[0].args[0].cmd, [...shebang_args, f.string, ...args_to_script])
@@ -306,7 +306,7 @@ Deno.test("x.ts", async runner => {
     const stub7 = mock.stub(_internals, "get_interpreter", async () => ({project: 'foo.com', args: shebang_args}))
 
     try {
-      await specimen([f.string, ...args_to_script], opts)
+      await specimen({args: [f.string, ...args_to_script], ...opts})
 
       assertEquals(stub1.calls.length, 1)
       assertEquals(stub1.calls[0].args[0].cmd, [...shebang_args, f.string, ...args_to_script])
@@ -328,7 +328,7 @@ Deno.test("x.ts", async runner => {
     const shebang_args = ['pkgx', 'bar']
     const stub = mock.stub(_internals, "get_shebang", () => Promise.resolve(shebang_args))
     try {
-      await assertRejects(() => specimen([f.string], opts), PkgxError)
+      await assertRejects(() => specimen({args: [f.string], ...opts}), PkgxError)
     } finally {
       stub.restore()
     }
@@ -339,7 +339,7 @@ Deno.test("x.ts", async runner => {
     const f = Path.mktemp().join('foo').touch()
     const stub = mock.stub(_internals, "get_shebang", () => Promise.resolve(['pkgx']))
     try {
-      await assertRejects(() => specimen([f.string], opts), PkgxError)
+      await assertRejects(() => specimen({args: [f.string], ...opts}), PkgxError)
     } finally {
       stub.restore()
     }
@@ -349,7 +349,7 @@ Deno.test("x.ts", async runner => {
     const f = Path.mktemp().join('foo').touch()
     const stub = mock.stub(_internals, "get_shebang", () => Promise.resolve(['pkgx']))
     try {
-      await assertRejects(() => specimen([f.string], opts), PkgxError)
+      await assertRejects(() => specimen({args: [f.string], ...opts}), PkgxError)
     } finally {
       stub.restore()
     }
@@ -360,7 +360,7 @@ Deno.test("x.ts", async runner => {
     const stub1 = mock.stub(_internals, "get_shebang", () => Promise.resolve(['foo']))
     const stub2 = mock.stub(_internals, "which", () => Promise.resolve(undefined))
     try {
-      await assertRejects(() => specimen([f.string], opts), PkgxError)
+      await assertRejects(() => specimen({args: [f.string], ...opts}), PkgxError)
     } finally {
       stub1.restore()
       stub2.restore()

--- a/src/modes/x.ts
+++ b/src/modes/x.ts
@@ -11,27 +11,33 @@ const { usePantry, useSync } = hooks
 //TODO be able to parse @latest for shebang result
 
 
-export default async function(args: string[], { pkgs: dry, ...opts }: {
+export default async function({ args, unknown, pkgs: dry, ...opts }: {
   update: boolean | Set<string>,
   pkgs?: PackageRequirement[],
-  logger: Logger
+  logger: Logger,
+  args: string[],
+  unknown: string[]
 }) {
   const { install, exec, construct_env, getenv } = _internals
 
   dry ??= []
 
   //TODO if contains PATH items then go directly to isFile path
-  const wut = await find_it(args, dry)
-  if (wut.pkg) dry.push(wut.pkg)
-  args = wut.args
+  if (args.length) {
+    const wut = await find_it(args, dry)
+    if (wut.pkg) dry.push(wut.pkg)
+    args = wut.args
 
-  if (wut.update) {
-    if (opts.update instanceof Set) {
-      opts.update.add(wut.pkg!.project)
-    } else if (!opts.update) {
-      opts.update = new Set([wut.pkg!.project])
+    if (wut.update) {
+      if (opts.update instanceof Set) {
+        opts.update.add(wut.pkg!.project)
+      } else if (!opts.update) {
+        opts.update = new Set([wut.pkg!.project])
+      }
     }
   }
+
+  args.push(...unknown)
 
   const pkgenv = await install(dry, opts)
   const env = await construct_env(pkgenv)

--- a/src/parse-args.test.ts
+++ b/src/parse-args.test.ts
@@ -16,7 +16,7 @@ Deno.test("parse_args.ts", async runner => {
     const rv = parse_args(['+foo', '--', ...args])
     if (rv.mode !== 'x') fail()
     assertEquals(rv.pkgs.plus, ["foo"])
-    assertEquals(rv.args, args)
+    assertEquals(rv.unknown, args)
   })
 
   await runner.step("--long-args", async runner => {
@@ -68,13 +68,6 @@ Deno.test("parse_args.ts", async runner => {
       const args = faker_args()
       assertThrows(() => parse_args(['--dry-run', '--help', ...args]))
     })
-  })
-
-  await runner.step("run", () => {
-    const args = faker_args()
-    const rv = parse_args(['run', ...args])
-    if (rv.mode != 'run') fail()
-    assertEquals(rv.args, args)
   })
 
   await runner.step("provider", () => {

--- a/src/parse-args.ts
+++ b/src/parse-args.ts
@@ -13,6 +13,7 @@ export type Args = {
   {
     mode: 'x' | 'run'
     args: string[]
+    unknown: string[]
     pkgs: Pkgs
   } | {
     mode: 'internal.use'
@@ -50,6 +51,7 @@ export default function(input: string[]): Args {
   const it = input[Symbol.iterator]()
   const pkgs: Pkgs = { plus: [], minus: [] }
   const args: string[] = []
+  const unknown: string[] = []
   const flags: Flags = {
     sync: false,
     update: false
@@ -111,7 +113,7 @@ export default function(input: string[]): Args {
         break
       case '':
         // empty the main loop iterator
-        for (const arg of it) args.push(arg)
+        for (const arg of it) unknown.push(arg)
         break
       default: {
         const match = content.match(/^verbose(=-?\d+)?$/)
@@ -135,15 +137,13 @@ export default function(input: string[]): Args {
 
   switch (mode) {
   case undefined:
-    if (args.length) {
-      return { mode: 'x', flags, pkgs, args }
+    if (args.length + unknown.length) {
+      return { mode: 'x', flags, pkgs, args, unknown }
     } else {
       return { mode: 'env', flags, pkgs }
     }
   case 'internal.use':
     return { mode, flags, pkgs }
-  case 'run':
-    return { mode, flags, pkgs, args }
   case 'provider':
   case 'shell-completion':
     return { mode, flags, args }


### PR DESCRIPTION
This allows `pkgx +brewkit -- pkg build` to work as well as using system utilities without full paths