### PR TITLE
Add support for .nvmrc

### DIFF
--- a/src/utils/devenv.ts
+++ b/src/utils/devenv.ts
@@ -26,6 +26,7 @@ export default async function(dir: Path) {
       case "deno.jsonc":
         await deno(path)
         break
+      case ".nvmrc":
       case ".node-version":
         await version_file(path, 'nodejs.org')
         break


### PR DESCRIPTION
Entered a project today where the Node version was specified in a .nvmrc file and pkgx didn't pick it up, so I thought I'd add it.

Specification: https://github.com/nvm-sh/nvm#nvmrc

I'm a little worried about their special cases ("lts/*" and "node" for latest, but I'm unsure how to handle that in pkgx or if we even should.