### PR TITLE
Only define `x` if available; Refs #857

### DIFF
--- a/.github/workflows/ci.shellcode.yml
+++ b/.github/workflows/ci.shellcode.yml
@@ -429,7 +429,7 @@ jobs:
           name: pkgx
       - name: prep
         run: |
-          apt-get update && apt-get --yes install zsh libatomic1
+          sudo apt-get update && sudo apt-get --yes install zsh libatomic1
           chmod u+x /usr/local/bin/pkgx
         shell: sh
 

--- a/.github/workflows/ci.shellcode.yml
+++ b/.github/workflows/ci.shellcode.yml
@@ -415,3 +415,19 @@ jobs:
             echo 'dev did not fail when already activated' >&2
             exit 1
           fi
+
+  x-already-defined-works:
+    needs: compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          path: /usr/local/bin
+          name: pkgx
+      - name: prep
+        run: chmod u+x /usr/local/bin/pkgx
+
+      - run: |
+          alias x="echo hi"
+          eval "$(pkgx --shellcode)"
+          test "$(x)" = hi

--- a/.github/workflows/ci.shellcode.yml
+++ b/.github/workflows/ci.shellcode.yml
@@ -419,6 +419,9 @@ jobs:
   x-already-defined-works:
     needs: compile
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: zsh -eo pipefail {0}
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.shellcode.yml
+++ b/.github/workflows/ci.shellcode.yml
@@ -428,7 +428,10 @@ jobs:
           path: /usr/local/bin
           name: pkgx
       - name: prep
-        run: chmod u+x /usr/local/bin/pkgx
+        run: |
+          apt-get update && apt-get --yes install zsh libatomic1
+          chmod u+x /usr/local/bin/pkgx
+        shell: sh
 
       - run: |
           alias x="echo hi"

--- a/.github/workflows/ci.shellcode.yml
+++ b/.github/workflows/ci.shellcode.yml
@@ -432,7 +432,6 @@ jobs:
           sudo apt-get update && sudo apt-get --yes install zsh libatomic1
           chmod u+x /usr/local/bin/pkgx
         shell: sh
-
       - run: |
           alias x="echo hi"
           eval "$(pkgx --shellcode)"

--- a/src/modes/shellcode.ts
+++ b/src/modes/shellcode.ts
@@ -45,7 +45,7 @@ export default function() {
     }
 
     if ! type x >/dev/null 2>&1; then
-      x() {
+      eval 'x() {
         case $1 in
         "")
           if [ -f "${tmp}/shellcode/x.$$" ]; then
@@ -62,7 +62,7 @@ export default function() {
         *)
           command pkgx -- "$@";;
         esac
-      }
+      }'
     fi
 
     env() {
@@ -80,8 +80,8 @@ export default function() {
       done
       if [ $# -eq 0 ]; then
         command env
-      fi
-      if type _pkgx_reset >/dev/null 2>&1; then
+        return
+      elif type _pkgx_reset >/dev/null 2>&1; then
         _pkgx_reset
       fi
       eval "$(command pkgx --internal.use "$@")"

--- a/src/modes/shellcode.ts
+++ b/src/modes/shellcode.ts
@@ -44,24 +44,26 @@ export default function() {
       esac
     }
 
-    x() {
-      case $1 in
-      "")
-        if [ -f "${tmp}/shellcode/x.$$" ]; then
-          if foo="$("${tmp}/shellcode/u.$$")"; then
-            eval "$foo"
-            ${sh} "${tmp}/shellcode/x.$$"
-            unset foo
-          fi
-          rm "${tmp}/shellcode/"?.$$
-        else
-          echo "pkgx: nothing to run" >&2
-          return 1
-        fi;;
-      *)
-        command pkgx -- "$@";;
-      esac
-    }
+    if ! type x >/dev/null 2>&1; then
+      x() {
+        case $1 in
+        "")
+          if [ -f "${tmp}/shellcode/x.$$" ]; then
+            if foo="$("${tmp}/shellcode/u.$$")"; then
+              eval "$foo"
+              ${sh} "${tmp}/shellcode/x.$$"
+              unset foo
+            fi
+            rm "${tmp}/shellcode/"?.$$
+          else
+            echo "pkgx: nothing to run" >&2
+            return 1
+          fi;;
+        *)
+          command pkgx -- "$@";;
+        esac
+      }
+    fi
 
     env() {
       for arg in "$@"; do


### PR DESCRIPTION
Note that this doesn’t change the behavior of the command not found handler, that should be a separate more involved fix.