### PR TITLE
Update action node version

### DIFF
--- a/fixtures/action.yml/std/action.yml
+++ b/fixtures/action.yml/std/action.yml
@@ -1,5 +1,5 @@
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'
 
 pkgx:


### PR DESCRIPTION
Github runners using node16 are being deprecated