### PR TITLE
deno 1.40 shows unskippable warnings at runtime

### DIFF
--- a/.github/workflows/ci.shellcode.yml
+++ b/.github/workflows/ci.shellcode.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: denoland/setup-deno@v1
         with:
-          deno-version: 1.39
+          deno-version: '1.39'
       - uses: actions/checkout@v4
       - run: deno task compile
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v1   # using ourself to install deno could compromise the tests
         with:
-          deno-version: '1.40'
+          deno-version: '1.39'
       - run: deno cache **/*.test.ts
       - run: deno task test --coverage=cov_profile --no-check
       - run: deno coverage cov_profile --lcov --exclude=tests/ --output=cov_profile.lcov
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v1   # using ourself to install deno could compromise the tests
         with:
-          deno-version: '1.40'
+          deno-version: '1.39'
       - run: deno lint
 
   typecheck:
@@ -68,5 +68,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v1
         with:
-          deno-version: '1.40'
+          deno-version: '1.39'
       - run: deno task typecheck

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -21,7 +21,7 @@
     "typecheck": "deno check ./entrypoint.ts",
     "compile": "deno compile --lock=deno.lock --allow-read --allow-write --allow-net --allow-run --allow-env --allow-ffi --unstable-ffi --unstable-fs --output $INIT_CWD/pkgx ./entrypoint.ts"
   },
-  "pkgx": "deno~1.40.2",
+  "pkgx": "deno~1.39",
   "lint": {
     "exclude": ["src/**/*.test.ts"]
   },


### PR DESCRIPTION
for deprecated API that we cannot yet remove in libpkgx