### PR TITLE
feat: Prepare for Deno 2.0 migrations (use no deprecated APIs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v1   # using ourself to install deno could compromise the tests
         with:
-          deno-version: 1.39
+          deno-version: 1.40
       - run: deno lint
 
   typecheck:
@@ -68,5 +68,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v1
         with:
-          deno-version: 1.39
+          deno-version: 1.40
       - run: deno task typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v1   # using ourself to install deno could compromise the tests
         with:
-          deno-version: 1.39
+          deno-version: 1.40
       - run: deno cache **/*.test.ts
       - run: deno task test --coverage=cov_profile --no-check
       - run: deno coverage cov_profile --lcov --exclude=tests/ --output=cov_profile.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v1   # using ourself to install deno could compromise the tests
         with:
-          deno-version: v.1x
+          deno-version: v1.x
       - run: deno cache **/*.test.ts
       - run: deno task test --coverage=cov_profile --no-check
       - run: deno coverage cov_profile --lcov --exclude=tests/ --output=cov_profile.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v1   # using ourself to install deno could compromise the tests
         with:
-          deno-version: 1.40
+          deno-version: v.1x
       - run: deno cache **/*.test.ts
       - run: deno task test --coverage=cov_profile --no-check
       - run: deno coverage cov_profile --lcov --exclude=tests/ --output=cov_profile.lcov
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v1   # using ourself to install deno could compromise the tests
         with:
-          deno-version: 1.40
+          deno-version: v1.x
       - run: deno lint
 
   typecheck:
@@ -68,5 +68,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v1
         with:
-          deno-version: 1.40
+          deno-version: v1.x
       - run: deno task typecheck

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -21,7 +21,7 @@
     "typecheck": "deno check --unstable ./entrypoint.ts",
     "compile": "deno compile --lock=deno.lock --allow-read --allow-write --allow-net --allow-run --allow-env --allow-ffi --unstable-ffi --unstable-fs --output $INIT_CWD/pkgx ./entrypoint.ts"
   },
-  "pkgx": "deno~1.39",
+  "pkgx": "deno>=1.40",
   "lint": {
     "exclude": ["src/**/*.test.ts"]
   },

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -5,12 +5,12 @@
   },
   "tasks": {
     // runs this source checkout, args will be passed
-    "run": "deno run --unstable -A ./entrypoint.ts",
+    "run": "deno run --unstable-ffi --unstable-fs -A ./entrypoint.ts",
 
     // you can specify paths to specific tests if you need
     // follows is the ideal permissions lines, unfortunately deno considers making symlinks to require full read/write permissions for fuck knows why reasons
     //"test": "deno test --allow-read=$PWD,$TMPDIR,$HOME,/ --allow-env --allow-write=$TMPDIR --allow-ffi --unstable",
-    "test": "deno test --allow-read --allow-env --allow-write --allow-ffi --unstable",
+    "test": "deno test --allow-read --allow-env --allow-write --allow-ffi --unstable-ffi --unstable-fs",
     // ^^ ffi & unstable needed for execve.ts
 
     // installs to /usr/local/bin/pkgx
@@ -19,7 +19,7 @@
     //--------------------------------------- ci/cd/admin
     "coverage" : "scripts/run-coverage.sh",
     "typecheck": "deno check --unstable ./entrypoint.ts",
-    "compile": "deno compile --lock=deno.lock --allow-read --allow-write --allow-net --allow-run --allow-env --allow-ffi --unstable --output $INIT_CWD/pkgx ./entrypoint.ts"
+    "compile": "deno compile --lock=deno.lock --allow-read --allow-write --allow-net --allow-run --allow-env --allow-ffi --unstable-ffi --unstable-fs --output $INIT_CWD/pkgx ./entrypoint.ts"
   },
   "pkgx": "deno~1.39",
   "lint": {

--- a/entrypoint.ts
+++ b/entrypoint.ts
@@ -7,7 +7,7 @@ import { render as perror } from "./src/err-handler.ts"
 import { setColorEnabled } from "deno/fmt/colors.ts"
 import clicolor from "./src/utils/clicolor.ts"
 
-setColorEnabled(clicolor(Deno.stderr.rid))
+setColorEnabled(clicolor(Deno.stderr))
 
 ///////////////////////////////////////////////////////// backwards compatability
 const argstr = Deno.args.join(' ')
@@ -71,7 +71,7 @@ try {
 
 /////////////////////////////////////////////////////////////////////////// utils
 function logger_prefix() {
-  if (Deno.env.get("CI") || !Deno.isatty(Deno.stdin.rid)) {
+  if (Deno.env.get("CI") || !Deno.stdin.isTerminal()) {
     return 'pkgx'
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -92,7 +92,7 @@ export default async function({ flags, ...opts }: Args, logger_prefix?: string) 
     console.log(shellcode())
     break
   case 'help':
-    setColorEnabled(clicolor(Deno.stdout.rid))
+    setColorEnabled(clicolor(Deno.stdout))
     console.log(help(flags.verbosity))
     break
   case 'env': {
@@ -122,7 +122,7 @@ async function ensure_pantry() {
 
 function make_logger(verbosity: number, logger_prefix?: string): IInstallLogger {
   const logger = new Logger(logger_prefix)
-  if (verbosity <= -2 || !Deno.isatty(Deno.stderr.rid)) {
+  if (verbosity <= -2 || !Deno.stderr.isTerminal()) {
     return {
       replace: () => {},
       clear: () => {},

--- a/src/modes/integrate.test.ts
+++ b/src/modes/integrate.test.ts
@@ -73,14 +73,4 @@ describe("integrate.ts", () => {
   }, async () => {
     await assertRejects(() => specimen("install"))
   })
-
-  it("isatty", async function() {
-    const stub = mock.stub(_internals, "isatty", () => true)
-    try {
-      file.touch()
-      await specimen("install")
-    } finally {
-      stub.restore()
-    }
-  })
 })

--- a/src/modes/integrate.ts
+++ b/src/modes/integrate.ts
@@ -80,7 +80,7 @@ export default async function(op: 'install' | 'uninstall', { dryrun }: { dryrun:
     }
     break
   case 'install':
-    if (!_internals.isatty(Deno.stdout.rid)) {
+    if (!Deno.stdout.isTerminal()) {
       // we're being sourced, output the hook
       _internals.stdout(shellcode())
     } else if (opd_at_least_once) {
@@ -125,7 +125,6 @@ function shells(): [Path, string][] {
 export const _internals = {
   home: Path.home,
   host,
-  isatty: Deno.isatty,
   stdout: console.log,
   stderr: console.error
 }

--- a/src/utils/clicolor.ts
+++ b/src/utils/clicolor.ts
@@ -1,5 +1,5 @@
 
-export default function(dst = Deno.stdout.rid, env = Deno.env.toObject()) {
+export default function(dst = Deno.stdout, env = Deno.env.toObject()) {
   // interprets https://no-color.org
   // see: https://deno.land/api@v1.37.1?s=Deno.noColor
   if (Deno.noColor) {
@@ -8,9 +8,9 @@ export default function(dst = Deno.stdout.rid, env = Deno.env.toObject()) {
 
   //https://bixense.com/clicolors/
 
-  //NOTE we (mostly) only output colors to stderr hence the isatty check for that
+  //NOTE we (mostly) only output colors to stderr hence the isTerminal check for that
   //FIXME not true for --help tho
-  if (env.CLICOLOR !== '0' && Deno.isatty(dst)) {
+  if (env.CLICOLOR !== '0' && dst.isTerminal()) {
     return true
   }
   if ((env.CLICOLOR_FORCE ?? '0') != '0') {


### PR DESCRIPTION
Prepares for migration to Deno 2.0

# Changes
`Deno.isatty(*.rid)` -> `Deno.*.isTerminal()`
`clicolor(*.rid)` -> `clicolor(*)`

I also removed the `isatty` test and removed `isatty` fom `$_internals`.
I also replaced `--unstable` flag with `--unstable-ffi` and `--unstable-fs`.