### PR TITLE
Fix dev off when environment is not active

### DIFF
--- a/src/modes/internal.activate.ts
+++ b/src/modes/internal.activate.ts
@@ -95,7 +95,7 @@ export default async function(dir: Path, { powder, ...opts }: { powder: PackageR
       env ${off_string}
 
       if [ "$1" != --shy ]; then
-        rm "${persistence}"
+        rm -f "${persistence}"
       fi
 
       unset -f _pkgx_dev_off _pkgx_should_deactivate_devenv

--- a/src/modes/shellcode.ts
+++ b/src/modes/shellcode.ts
@@ -55,7 +55,7 @@ export default function() {
               ${sh} "${tmp}/shellcode/x.$$"
               unset foo
             fi
-            rm "${tmp}/shellcode/"?.$$
+            rm -f "${tmp}/shellcode/"?.$$
           else
             echo "pkgx: nothing to run" >&2
             return 1
@@ -90,7 +90,12 @@ export default function() {
 
     dev() {
       if [ "$1" = 'off' ]; then
-        _pkgx_dev_off
+        if type _pkgx_dev_off >/dev/null 2>&1; then
+          _pkgx_dev_off
+        else
+          echo 'dev: environment not active' >&2
+          return 1
+        fi
       elif type _pkgx_dev_off >/dev/null 2>&1; then
         echo 'dev: environment already active' >&2
         return 1


### PR DESCRIPTION
Which was previously throwing _pkgx_dev_off not found.

And also make sure to pass rm -f as some people alias rm to rm -i, which can come from the popular OMZ common-aliases: https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/common-aliases#file-handling