### PR TITLE
Update ci-cd.md documentation

### DIFF
--- a/docs/run/anywhere/ci-cd.md
+++ b/docs/run/anywhere/ci-cd.md
@@ -3,14 +3,14 @@
 ## GitHub Actions
 
 ```sh
-- uses: pkgxdev/setup@v1
+- uses: pkgxdev/setup@v2
 - run: pkgx go@1.20 build
 ```
 
 Installs `pkgx` so you can then run `go build` with go version ^1.20.
 
 ```sh
-- uses: pkgxdev/setup@v1
+- uses: pkgxdev/setup@v2
   with:
     +: node@16
 - run: node --version
@@ -22,7 +22,7 @@ Installs `pkgx` so you can then run `go build` with go version ^1.20.
 
 ```sh
 - uses: actions/checkout@v3
-- uses: pkgxdev/dev@v1
+- uses: pkgxdev/dev@v0
 ```
 
 The developer environment for your project will be available during the job.


### PR DESCRIPTION
The existing documentation is pointing to:
- Old pkgxdev/setup version
- Non existing pkgdxdev/dev version ([only v0 exists](https://github.com/pkgxdev/dev/tags))

On a separate subject, maintainers should consider publishing `pkgxdev/dev` in [Github Actions Marketplace](https://github.com/marketplace?category=&type=actions&verification=&query=sort%3Apopularity-desc+pkgx) as only `pkgxdev/setup` is there atm.