### PR TITLE
Error when a different version is already installed

### DIFF
--- a/src/modes/install.ts
+++ b/src/modes/install.ts
@@ -67,6 +67,9 @@ export default async function(pkgs: PackageRequirement[]) {
             }
             const found = value.match(/^\s*exec pkgx \+([^ ]+)/)?.[1]
             if (found) {
+              if (found != pkgstr) {
+                throw new PkgxError(`different version already installed: ${blurple(program)} ${dim(`(${found})`)}`)
+              }
               n++
               console.warn(`pkgx: already installed: ${blurple(program)} ${dim(`(${found})`)}`)
               continue program_loop


### PR DESCRIPTION
This is just a quick take on #998.

Ideally, pkgx should be able to handle this case by first uninstalling the existing package and then installing the desired one, which would in turn make scripting with pkgx a lot easier.
