### PR TITLE
Escape spaces in stubs for uninstallation

### DIFF
--- a/src/modes/install.ts
+++ b/src/modes/install.ts
@@ -45,7 +45,7 @@ export default async function(pkgs: PackageRequirement[]) {
             ${exec}
           else
             cd "$(dirname "$0")"
-            rm ${programs.join(' ')} && echo "uninstalled: ${pkgstr}" >&2
+            rm -f ${programs.map(p => `'${p}'`).join(' ')} && echo "uninstalled: ${pkgstr}" >&2
           fi`
         const f = dst.mkdir('p').join(program)
 


### PR DESCRIPTION
I noticed this problem when trying to uninstall Python:

![image](https://github.com/pkgxdev/pkgx/assets/29582865/7ab93b34-c2d3-42ca-bbbd-ddc81dff927d)

Obviously, the source problem is something else that should be fixed. But nevertheless, the stubs should be protected. There may exist some real program name with spaces as well, for example.

## Before

![image](https://github.com/pkgxdev/pkgx/assets/29582865/06fca738-da12-4dea-a2a6-ee9170acbd37)

## After

![image](https://github.com/pkgxdev/pkgx/assets/29582865/98d3b67c-1343-43b2-9c99-8b4fb6961c2a)
