### PR TITLE
Upgrade Deno from v2.0.2 to v2.1.4

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -86,7 +86,7 @@ jobs:
     # - uses: pkgxdev/dev@v0
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: ^2.1.0
+          deno-version: ^2.1.1
 
       - run: deno task compile
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -86,7 +86,7 @@ jobs:
     # - uses: pkgxdev/dev@v0
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: ^2.0.2
+          deno-version: ^2.1.0
 
       - run: deno task compile
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -86,7 +86,7 @@ jobs:
     # - uses: pkgxdev/dev@v0
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: ^2.1.1
+          deno-version: ^2.1.4
 
       - run: deno task compile
 

--- a/.github/workflows/ci.shellcode.yml
+++ b/.github/workflows/ci.shellcode.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: ^2.0.2
+          deno-version: ^2.1.0
       - uses: actions/checkout@v4
       - run: deno task compile
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.shellcode.yml
+++ b/.github/workflows/ci.shellcode.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: ^2.1.1
+          deno-version: ^2.1.4
       - uses: actions/checkout@v4
       - run: deno task compile
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.shellcode.yml
+++ b/.github/workflows/ci.shellcode.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: ^2.1.0
+          deno-version: ^2.1.1
       - uses: actions/checkout@v4
       - run: deno task compile
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2   # using ourself to install deno could compromise the tests
         with:
-          deno-version: ^2.1.0
+          deno-version: ^2.1.1
       - run: deno cache **/*.test.ts
       - run: deno task test --coverage=cov_profile --no-check
       - run: deno coverage cov_profile --lcov --exclude=tests/ --output=cov_profile.lcov
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2   # using ourself to install deno could compromise the tests
         with:
-          deno-version: ^2.1.0
+          deno-version: ^2.1.1
       - run: deno lint
 
   typecheck:
@@ -68,5 +68,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: ^2.1.0
+          deno-version: ^2.1.1
       - run: deno task typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2   # using ourself to install deno could compromise the tests
         with:
-          deno-version: ^2.1.1
+          deno-version: ^2.1.4
       - run: deno cache **/*.test.ts
       - run: deno task test --coverage=cov_profile --no-check
       - run: deno coverage cov_profile --lcov --exclude=tests/ --output=cov_profile.lcov
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2   # using ourself to install deno could compromise the tests
         with:
-          deno-version: ^2.1.1
+          deno-version: ^2.1.4
       - run: deno lint
 
   typecheck:
@@ -68,5 +68,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: ^2.1.1
+          deno-version: ^2.1.4
       - run: deno task typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2   # using ourself to install deno could compromise the tests
         with:
-          deno-version: ^2.0.2
+          deno-version: ^2.1.0
       - run: deno cache **/*.test.ts
       - run: deno task test --coverage=cov_profile --no-check
       - run: deno coverage cov_profile --lcov --exclude=tests/ --output=cov_profile.lcov
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2   # using ourself to install deno could compromise the tests
         with:
-          deno-version: ^2.0.2
+          deno-version: ^2.1.0
       - run: deno lint
 
   typecheck:
@@ -68,5 +68,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: ^2.0.2
+          deno-version: ^2.1.0
       - run: deno task typecheck

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -17,7 +17,7 @@
     "typecheck": "deno check ./entrypoint.ts",
     "compile": "deno compile --lock=deno.lock --allow-all --output \"$INIT_CWD/pkgx\" ./entrypoint.ts"
   },
-  "pkgx": "deno~2.1.0",
+  "pkgx": "deno~2.1.1",
   "lint": {
     "exclude": ["src/**/*.test.ts"]
   },

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -17,7 +17,7 @@
     "typecheck": "deno check ./entrypoint.ts",
     "compile": "deno compile --lock=deno.lock --allow-all --output \"$INIT_CWD/pkgx\" ./entrypoint.ts"
   },
-  "pkgx": "deno~2.1.1",
+  "pkgx": "deno~2.1.4",
   "lint": {
     "exclude": ["src/**/*.test.ts"]
   },

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -17,7 +17,7 @@
     "typecheck": "deno check ./entrypoint.ts",
     "compile": "deno compile --lock=deno.lock --allow-all --output \"$INIT_CWD/pkgx\" ./entrypoint.ts"
   },
-  "pkgx": "deno~2.0",
+  "pkgx": "deno~2.1.0",
   "lint": {
     "exclude": ["src/**/*.test.ts"]
   },


### PR DESCRIPTION
Here are some good reasons to upgrade to newest Deno:

1. Deno 2.1 is (or will be) the first ever LTS version of Deno

2. 7% speedier?

![image](https://github.com/user-attachments/assets/b07f8306-d708-4934-aef2-89f3c8beb184)

Simple Bash script I'm using to benchmark this:

```bash
#!/bin/bash

set -euxo pipefail

hyperfine_jobs=()
for v in 2.0.6 2.1.0; do
    deno clean
    deno upgrade $v
    deno task compile
    mv pkgx pkgx-deno-$v
    hyperfine_jobs+=("./pkgx-deno-$v git@2.44.0 --version")
done

exec pkgx hyperfine --warmup 2 --shell none --runs 50 "${hyperfine_jobs[@]}"
```