### PR TITLE
fix(install): fix unsafe install script (args passing)

### DIFF
--- a/src/modes/install.ts
+++ b/src/modes/install.ts
@@ -71,7 +71,7 @@ export default async function(pkgs: PackageRequirement[], unsafe: boolean) {
                   # shellcheck source=$ENV_FILE
                   . "$ENV_FILE"
                   set +a
-                  exec "$PKGX_DIR/${pkgstr}/v*/bin/${program}" "$ARGS"
+                  exec "$PKGX_DIR/${pkgstr}/v*/bin/${program}" $ARGS
                 else
                   pkgx_resolve
                 fi


### PR DESCRIPTION
The unsafe install thing (that was added recently), creates a bit different script as you know.
Well, in that, the args that you pass to the program were being passed as a single argument (`"$ARGS"`). So, here's the simple one-line solution.

cc @jhheider 