### PR TITLE
publish pkgx to crates.io

### DIFF
--- a/.github/workflows/cd.crates.yml
+++ b/.github/workflows/cd.crates.yml
@@ -1,0 +1,28 @@
+name: cd·crates
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      release-id:
+        required: true
+
+concurrency:
+  group: cd/crates/${{ github.event.release.tag_name || github.event.inputs.release-id }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.event.inputs.release-id }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: katyo/publish-crates@v2
+        with:
+          # TODO: remove --package to publish libpkgx as well
+          args: --package pkgx --all-features
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
```yaml
      - uses: katyo/publish-crates@v2
        with:
          # TODO: remove --package to publish libpkgx as well
          args: --package pkgx --all-features
          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
```