### PR TITLE
If PKGX_PANTRY_DIR is set, don’t blow it away

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,22 @@ jobs:
             exit 1
           fi
 
+      # check that we update the pantry for unknown programs
+      # this works by deleting the entry for git then forcing
+      # pkgx to update the db, then trying to get git again
+      - run: |
+          set -x
+          rm -rf ~/.pkgx
+          rm -rf ~/.cache/pkgx/pantry/projects/git-scm.org
+          rm ~/.cache/pkgx/pantry.2.db
+          pkgx curl --version
+          test -f ~/.cache/pkgx/pantry.2.db
+          test ! -d ~/.cache/pkgx/pantry/projects/git-scm.org
+          pkgx git --version
+          test -d ~/.cache/pkgx/pantry/projects/git-scm.org
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        # ^^ only on one platform as wasteful otherwise
+
       - name: generate coverage
         run: |
           cargo install rustfilt

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         if let Some(spinner) = &spinner {
             spinner.set_message("syncing pkg-db…");
         }
-        sync::replace(&config, &mut conn).await?;
+        sync::ensure(&config, &mut conn).await?;
         true
     } else {
         false
@@ -112,7 +112,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         spinner.set_message(msg);
                     }
                     // cmd not found ∴ sync in case it is new
-                    sync::replace(&config, &mut conn).await?;
+                    sync::update(&config, &mut conn).await?;
                     if let Some(spinner) = &spinner {
                         spinner.set_message("resolving pkg graph…");
                     }


### PR DESCRIPTION
We assume if the user sets PKGX_PANTRY_DIR that they are managing its updates themselves.