### PR TITLE
Clone pantry to same location as pkgx^1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,13 +133,13 @@ jobs:
       - run: |
           set -x
           rm -rf ~/.pkgx
-          rm -rf ~/.cache/pkgx/pantry/projects/git-scm.org
+          rm -rf ~/.local/share/pkgx/pantry/projects/git-scm.org
           rm ~/.cache/pkgx/pantry.2.db
           pkgx curl --version
           test -f ~/.cache/pkgx/pantry.2.db
-          test ! -d ~/.cache/pkgx/pantry/projects/git-scm.org
+          test ! -d ~/.local/share/pkgx/pantry/projects/git-scm.org
           pkgx git --version
-          test -d ~/.cache/pkgx/pantry/projects/git-scm.org
+          test -d ~/.local/share/pkgx/pantry/projects/git-scm.org
         if: ${{ matrix.os == 'ubuntu-latest' }}
         # ^^ only on one platform as wasteful otherwise
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libpkgx"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1077,7 +1077,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "pkgx"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "console",
  "indicatif",
@@ -1467,15 +1467,15 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "ce1475c515a4f03a8a7129bb5228b81a781a86cb0b3fbbc19e1c556d491a401f"
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "9688894b43459159c82bfa5a5fa0435c19cbe3c9b427fa1dd7b1ce0c279b18a7"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -3,7 +3,7 @@ name = "pkgx"
 description = "Run anything"
 authors = ["Max Howell <mxcl@me.com>", "Jacob Heider <jacob@pkgx.dev>"]
 license = "Apache-2.0"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2021"
 repository = "https://github.com/pkgxdev/pkgx"
 
@@ -14,7 +14,7 @@ regex = "1.11.1"
 indicatif = "0.17.9"
 nix = { version = "0.29.0", features = ["process"] }
 serde_json = "1.0.135"
-libpkgx = { version = "0.3.1", path = "../lib" }
+libpkgx = { version = "0.3.2", path = "../lib" }
 console = { version = "0.15", default-features = false, features = [
   "ansi-parsing",
 ] }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -44,9 +44,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let config = Config::new()?;
 
-    let cache_dir = config.pantry_dir.parent().unwrap();
-    std::fs::create_dir_all(cache_dir)?;
-    let mut conn = Connection::open(cache_dir.join("pantry.2.db"))?;
+    std::fs::create_dir_all(config.pantry_db_file.parent().unwrap())?;
+    let mut conn = Connection::open(&config.pantry_db_file)?;
 
     let spinner = if flags.silent || flags.quiet {
         None

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -3,7 +3,7 @@ name = "libpkgx"
 description = "Install and run `pkgx` packages"
 authors = ["Max Howell <mxcl@me.com>", "Jacob Heider <jacob@pkgx.dev>"]
 license = "Apache-2.0"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 repository = "https://github.com/pkgxdev/pkgx"
 

--- a/crates/lib/src/sync.rs
+++ b/crates/lib/src/sync.rs
@@ -12,10 +12,9 @@ pub fn should(config: &Config) -> Result<bool, Box<dyn Error>> {
     if !config.pantry_dir.join("projects").is_dir() {
         Ok(true)
     } else {
-        let path = config.pantry_dir.parent().unwrap().join("pantry.2.db");
         // the file always exists because we create the connection
         // but will be 0 bytes if we need to fill it
-        Ok(std::fs::metadata(&path)?.len() == 0)
+        Ok(std::fs::metadata(&config.pantry_db_file)?.len() == 0)
     }
 }
 
@@ -51,7 +50,7 @@ async fn replace(config: &Config, conn: &mut Connection) -> Result<(), Box<dyn E
     let url = env!("PKGX_PANTRY_TARBALL_URL");
     let dest = &config.pantry_dir;
 
-    std::fs::create_dir_all(dest.clone())?;
+    std::fs::create_dir_all(dest)?;
     let dir = OpenOptions::new()
         .read(true) // Open in read-only mode; no need to write.
         .open(dest)?;


### PR DESCRIPTION
This change was thoughtless and accidental. It means we can end up with pkgx^1 and pkgx^2 getting out of sync.