### PR TITLE
Revamp docker image

### DIFF
--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -1,0 +1,1 @@
+/products

--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,16 +1,11 @@
-FROM debian:buster-slim AS stage0
+FROM debian:bookworm-slim AS base
+
+FROM base AS install
 COPY ./products/* /pkgx/
 RUN install -m 755 /pkgx/$(uname -m) /usr/local/bin/pkgx
 RUN install -m 755 /pkgx/pkgm /usr/local/bin/pkgm
-RUN echo 'export PS1="\\[\\033[38;5;63m\\]pkgx\\[\\033[0m\\]\\w $ "' >> /root/.bashrc
 
-FROM debian:buster-slim AS stage1
-RUN apt-get update && apt --yes install libc-dev libstdc++-8-dev libgcc-8-dev netbase libudev-dev ca-certificates
-COPY --from=stage0 /usr/local/bin/pkgx /usr/local/bin/pkgx
-COPY --from=stage0 /usr/local/bin/pkgm /usr/local/bin/pkgm
-COPY --from=stage0 /root/.bashrc /root/.bashrc
-ENV BASH_ENV=/root/.bashrc
-ENV CLICOLOR_FORCE=1
-SHELL ["/bin/bash", "-c"]
-CMD ["/bin/bash", "-i"]
+FROM base
+COPY --from=install /usr/local/bin/pkgx /usr/local/bin/pkgm /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/pkgx"]
+CMD ["/bin/bash"]


### PR DESCRIPTION
1. Update Debian from 10 to 12 (current latest)
2. Avoid installing apt-get dependencies, pkgx is meant to handle them all I suppose (maybe they were needed by pkgx v1?)
3. Remove bashrc craziness, they cause issues when running image as a different user like `--user $(id -u):$(id -g)` and I don't see why they are needed
4. Remove `CLICOLOR_FORCE=1`. This is non-sense. pkgx v2 already adds colors when the container is being run with `-it`.

The old image size was 176MB, the new image size is 86.6MB.
