### PR TITLE
Improve error message for version intersection conflicts

### DIFF
--- a/crates/lib/src/hydrate.rs
+++ b/crates/lib/src/hydrate.rs
@@ -47,7 +47,8 @@ where
         let node = graph
             .entry(pkg.project.clone())
             .or_insert_with(|| Box::new(Node::new(pkg.clone(), None)));
-        node.pkg.constraint = intersect_constraints(&node.pkg.constraint, &pkg.constraint, &pkg.project)?;
+        node.pkg.constraint =
+            intersect_constraints(&node.pkg.constraint, &pkg.constraint, &pkg.project)?;
         stack.push(node.clone());
     }
 
@@ -56,8 +57,11 @@ where
             let child_node = graph
                 .entry(child_pkg.project.clone())
                 .or_insert_with(|| Box::new(Node::new(child_pkg.clone(), Some(current.clone()))));
-            let intersection =
-                intersect_constraints(&child_node.pkg.constraint, &child_pkg.constraint, &child_pkg.project);
+            let intersection = intersect_constraints(
+                &child_node.pkg.constraint,
+                &child_pkg.constraint,
+                &child_pkg.project,
+            );
             if let Ok(constraint) = intersection {
                 child_node.pkg.constraint = constraint;
                 current.children.insert(child_node.pkg.project.clone());
@@ -94,8 +98,9 @@ fn condense(pkgs: &Vec<PackageReq>) -> Vec<PackageReq> {
     let mut out: Vec<PackageReq> = vec![];
     for pkg in pkgs {
         if let Some(existing) = out.iter_mut().find(|p| p.project == pkg.project) {
-            existing.constraint = intersect_constraints(&existing.constraint, &pkg.constraint, &pkg.project)
-                .expect("Failed to intersect constraints");
+            existing.constraint =
+                intersect_constraints(&existing.constraint, &pkg.constraint, &pkg.project)
+                    .expect("Failed to intersect constraints");
         } else {
             out.push(pkg.clone());
         }
@@ -104,6 +109,11 @@ fn condense(pkgs: &Vec<PackageReq>) -> Vec<PackageReq> {
 }
 
 /// Intersects two version constraints.
-fn intersect_constraints(a: &VersionReq, b: &VersionReq, project_name: &str) -> Result<VersionReq, Box<dyn Error>> {
-    a.intersect(b).map_err(|e| format!("{} for {}: {} and {}", e, project_name, a, b).into())
+fn intersect_constraints(
+    a: &VersionReq,
+    b: &VersionReq,
+    project_name: &str,
+) -> Result<VersionReq, Box<dyn Error>> {
+    a.intersect(b)
+        .map_err(|e| format!("{} for {}: {} and {}", e, project_name, a, b).into())
 }

--- a/crates/lib/src/hydrate.rs
+++ b/crates/lib/src/hydrate.rs
@@ -47,7 +47,7 @@ where
         let node = graph
             .entry(pkg.project.clone())
             .or_insert_with(|| Box::new(Node::new(pkg.clone(), None)));
-        node.pkg.constraint = intersect_constraints(&node.pkg.constraint, &pkg.constraint)?;
+        node.pkg.constraint = intersect_constraints(&node.pkg.constraint, &pkg.constraint, &pkg.project)?;
         stack.push(node.clone());
     }
 
@@ -57,7 +57,7 @@ where
                 .entry(child_pkg.project.clone())
                 .or_insert_with(|| Box::new(Node::new(child_pkg.clone(), Some(current.clone()))));
             let intersection =
-                intersect_constraints(&child_node.pkg.constraint, &child_pkg.constraint);
+                intersect_constraints(&child_node.pkg.constraint, &child_pkg.constraint, &child_pkg.project);
             if let Ok(constraint) = intersection {
                 child_node.pkg.constraint = constraint;
                 current.children.insert(child_node.pkg.project.clone());
@@ -94,7 +94,7 @@ fn condense(pkgs: &Vec<PackageReq>) -> Vec<PackageReq> {
     let mut out: Vec<PackageReq> = vec![];
     for pkg in pkgs {
         if let Some(existing) = out.iter_mut().find(|p| p.project == pkg.project) {
-            existing.constraint = intersect_constraints(&existing.constraint, &pkg.constraint)
+            existing.constraint = intersect_constraints(&existing.constraint, &pkg.constraint, &pkg.project)
                 .expect("Failed to intersect constraints");
         } else {
             out.push(pkg.clone());
@@ -104,6 +104,6 @@ fn condense(pkgs: &Vec<PackageReq>) -> Vec<PackageReq> {
 }
 
 /// Intersects two version constraints.
-fn intersect_constraints(a: &VersionReq, b: &VersionReq) -> Result<VersionReq, Box<dyn Error>> {
-    a.intersect(b).map_err(|e| e.into())
+fn intersect_constraints(a: &VersionReq, b: &VersionReq, project_name: &str) -> Result<VersionReq, Box<dyn Error>> {
+    a.intersect(b).map_err(|e| format!("{} for {}: {} and {}", e, project_name, a, b).into())
 }


### PR DESCRIPTION
This PR enhances the error message when version intersection is not possible, making it easier to identify which packages are causing conflicts.

**Before:**
```
$ pkgx +nodejs.org@24 +openssl.org@3.6.0 openssl version
Error: no intersection possible
```
The error message was not informative, making it difficult to identify which packages were causing the conflict.

**After:**
```
$ pkgx +nodejs.org@24 +openssl.org@3.6.0 openssl version
Error: "no intersection possible for openssl.org: @3.6.0 and ^1.1"
```

The improved error message now includes:
- The package name causing the conflict
- The specific version constraints that couldn't be resolved

This allows users to much more quickly identify the root cause of the problem and fix it.

**pkgx version:** 2.7.0