### PR TITLE
Use SUDO_HOME environment variable to derive the pkgx directory if it is set

### DIFF
--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -69,6 +69,14 @@ fn get_pkgx_dir() -> io::Result<PathBuf> {
         }
     }
 
+    // Use sudoer home directory if it is set.
+    if let Ok(path) = env::var("SUDO_HOME") {
+        let path = PathBuf::from(path).join(".pkgx");
+        if path.is_absolute() {
+            return Ok(path);
+        }
+    }
+
     let default = dirs_next::home_dir().map(|x| x.join(".pkgx"));
 
     if default.clone().is_some_and(|x| x.exists()) {


### PR DESCRIPTION
This fixes an issue on Linux when using `sudo` which causes the pkgx directory to be located inside the root user home directory. This seems to be due to differences in how operating systems deal with `sudo` and the `HOME` environment variable. On macOS, the `HOME` variable is set to the home directory of the user calling the `sudo` command, but on Fedora it is set to the root user home directory. By using `SUDO_HOME` if it set, we fix the Linux behavior to be the same as on macOS.

Together with [this other PR](https://github.com/pkgxdev/pkgm/pull/75) in pkgm, this fixes calling `sudo pkgm install <package>` on Linux to install packages to `/usr/local/bin`. See full [discussion](https://github.com/pkgxdev/pkgx/issues/1218) for more information.